### PR TITLE
Implemented osc-lookup

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -36,12 +36,9 @@ io.on('connection', socket => {
 		var msg = obj.split(' ');
 		console.log('sent Web Client message to OSC Client', msg);
 		this.oscSend.send(...msg);
-
 	});
 	// When the Web Client disconnects
 	socket.on("disconnect", function () {
 		console.log('Web Client disconnected');
-		//this.webOn.close();
-		this.oscOn.close();
 	})
 });

--- a/components/osc-lookup.js
+++ b/components/osc-lookup.js
@@ -1,0 +1,95 @@
+AFRAME.registerComponent('osc-lookup', {
+    init: function () {
+        this.el.addEventListener('runOSC', this.runOSC);
+    },
+    _update: function(entity, component, property, value) {
+        // NOTE: The current method is a workaround for an AFRAME bug where
+        // setComponentProperty would not properly update position and rotation
+        // components.
+        entity.components[component].data[property] = value;
+        entity.components[component].update(entity.components[component].oldData)
+        //AFRAME.utils.entity.setComponentProperty(entity, `${component}.${property}`, value);
+    },
+    _set: function(entity, component, property, value) {
+		// Make sure the component has the property
+		if (entity.getAttribute(component)[property] == undefined) { return null; }
+		// Set the property to the given value
+        this._update(entity, component, property, value);
+		return value;
+	},
+	_add: function(entity, component, property, value) {
+		// Make sure the component has the property
+		let current = entity.getAttribute(component)[property];
+		if (current == undefined) { return null; }
+		// Can only add numbers
+		if (isNaN(current) || isNaN(value)) { return null; }
+		// Set the property to the given value
+		this._update(entity, component, property, value + current);
+		return value + current;
+	},
+	_sub: function(entity, component, property, value) {
+		// We can only negate numbers
+		if (isNaN(value)) { return null; }
+		// Add but with a negative value
+		return this._add(entity, component, property, -value);
+	},
+	_subs: function(entity, component, property, value, min) {
+		// Capture the new value in the property
+		let new_value = this._sub(entity, component, property, value);
+		// Return if it was not updated
+		if (new_value == null) { return new_value; }
+		// Make sure that the new value is not less than min
+		if (new_value < min) {
+			this._update(entity, component, property, min);
+			return 0;
+		}
+		return new_value;
+	},
+	_adds: function(entity, component, property, value, max) {
+        console.log('adds')
+		// Capture the new value in the property
+		let new_value = this._add(entity, component, property, value);
+		// Return if it was not updated
+		if (new_value == null) { return new_value; }
+		// Make sure that the new value is not more than max
+		if (new_value > max) {
+			this._update(entity, component, property, max);
+			return max;
+		}
+		return new_value;
+	},
+	_run: function(funct, c_name, args, id) {
+		var entities = document.querySelectorAll(`[${c_name}]`);
+		for (let i = 0; i < entities.length; ++i) {
+			// Check the entity's id
+			let e_id = AFRAME.utils.entity.getComponentProperty(entities[i], 'osc-receiver');
+
+            if (id == -2) { /* No checks */ }
+            else if (id == -1) { if (e_id == undefined) { continue; } }
+            else if (e_id < 0 || id != e_id) { continue; }
+            console.log(e_id)
+			// If we found the id to be valid (strictly true), call the function
+			funct.call(this, entities[i], ...args);
+		}
+	},
+    runOSC: function(message) {
+        var path = message[0].split('/');
+        var args = message.slice(1);
+        args.unshift(path[1]);
+        var id = 0;
+        // Check if command path is invalid
+        if (path.length != 3) { return; }
+        // Check the root path name (component or a special operator) and pass off the call
+        if (path[2] == 'adds' || path[2] == 'subs') {
+            if (args.length == 5) { id = args[4]; args = args.slice(0, 4); }
+            else if (args.length == 3) { args.push((path[2] == 'adds') ? 1 : 0); }
+            if (args.length != 4) { return; }
+            this._run.call(this, eval(`this._${path[2]}`), path[1], args, id);
+        }
+        else if (path[2] == 'set' || path[2] == 'add' || path[2] == 'sub') {
+            if (args.length == 4) { id = args[3]; args = args.slice(0, 3); }
+            if (args.length != 3) { return; }
+            this._run.call(this, eval(`this._${path[2]}`), path[1], args, id);
+        }
+    }
+})

--- a/components/osc-manager.js
+++ b/components/osc-manager.js
@@ -1,4 +1,5 @@
 AFRAME.registerComponent('osc-manager', {
+	dependencies: ['osc-lookup'],
 	schema: {
 		// Bridge Server to connect to
 		bridgeHost: { type: 'string', default: '127.0.0.1' },
@@ -6,15 +7,13 @@ AFRAME.registerComponent('osc-manager', {
 		oscHost: { type: 'string', default: '127.0.0.1' },
 		recievePort: { type: 'string', default: '3334' },
 		sendPort: { type: 'string', default: '3333' },
-		// Output line for internal broadcasting
-		line: { type: 'int', default: 0 }
 	},
 	init: function() {
+		var component = this;
 		// IO is imported in index.html
 		// Make the connection to the Bridge Server
-		console.log(`Attempting to connect to ${this.data.bridgeHost}:8081`);
-		var socket = io('http://' + this.data.bridgeHost + ':8081');
-		var component = this;
+		console.log(`Attempting to connect to ${component.data.bridgeHost}:8081`);
+		var socket = io('http://' + component.data.bridgeHost + ':8081');
 		// On connection sucess
 		socket.on('connect', function() {
 			// Log the sucesful connection
@@ -32,9 +31,10 @@ AFRAME.registerComponent('osc-manager', {
 			// Emit a connected message to any OSC listening
 			socket.emit('message', `/connected ${component.data.bridgeHost} ${component.data.recievePort}`);
 			// When we recieve an OSC message
-			socket.on('message', function(obj) {
-				// Log the message
-				console.log(obj);
+			socket.on('message', function(message) {
+				// Send the message off to the lookup component for parsing
+				console.log(component.el.components.position)
+				component.el.components['osc-lookup'].runOSC(message);
 			});
 		})
 	}

--- a/components/osc-receiver.js
+++ b/components/osc-receiver.js
@@ -1,0 +1,5 @@
+AFRAME.registerComponent('osc-receiver', {
+    schema: {
+        line: { type: 'int', default: 0 }
+    }
+})

--- a/index.html
+++ b/index.html
@@ -4,17 +4,19 @@
     <meta charset="utf-8">
     <title>Hello, World! - A-Frame</title>
     <meta name="description" content="Hello, World! - A-Frame">
-    <script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.2.0/aframe.min.js"></script>
     <script src="http://127.0.0.1:8081/socket.io/socket.io.js"></script>
     <script src="./components/osc-manager.js?v=2"></script>
+    <script src="./components/osc-receiver.js?v=2"></script>
+    <script src="./components/osc-lookup.js?v=2"></script>
   </head>
   <body>
     <a-scene>
-		<a-box position="-1 0.5 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
-		<a-sphere position="0 1.25 -5" radius="1.25" color="#EF2D5E"></a-sphere>
-		<a-cylinder position="1 0.75 -3" radius="0.5" height="1.5" color="#FFC65D" osc-manager="oscHost: 127.0.0.1; bridgeHost: 127.0.0.1"></a-cylinder>
+		<a-box position="-1 0.5 -3" rotation="0 45 0" color="#4CC3D9" osc-receiver="0"></a-box>
+		<a-sphere position="0 1.25 -5" radius="1.25" color="#EF2D5E" osc-receiver="1"></a-sphere>
+		<a-cylinder position="1 0.75 -3" rotation="0 45 0" radius="0.5" height="1.5" color="#FFC65D" osc-receiver="2"></a-cylinder>
 		<a-plane position="0 0 -4" rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
-		<a-sky color="#ECECEC"></a-sky>
+		<a-sky color="#ECECEC" osc-manager="oscHost: 127.0.0.1; bridgeHost: 127.0.0.1"></a-sky>
     </a-scene>
   </body>
 </html>


### PR DESCRIPTION
Added five potential OSC commands: set, add, adds, sub, and subs. Everything works fine on localhost and on private networks. osc-manager now requires osc-lookup, and also implemented the osc-receiver to finish off functionality.